### PR TITLE
probe/fbconfig: Texture-map a quadrangle using the "legacy" APIs

### DIFF
--- a/probe/fbconfig/fbconfig.c
+++ b/probe/fbconfig/fbconfig.c
@@ -7,6 +7,12 @@
 
 #include <unistd.h>
 
+#define TARGET_WIDTH 256
+#define TARGET_HEIGHT 256
+
+#define SOURCE_WIDTH 100
+#define SOURCE_HEIGHT 100
+
 #define CHECK_ERROR(context)                                         \
     do {                                                             \
         int error = glGetError();                                    \
@@ -79,7 +85,7 @@ int main(int argc, char *argv[])
     GLXWindow xWin = XCreateWindow(
         dpy,
         RootWindow(dpy, vInfo->screen),
-        0, 0, 256, 256, 0,
+        0, 0, TARGET_WIDTH, TARGET_HEIGHT, 0,
         vInfo->depth,
         InputOutput,
         vInfo->visual,
@@ -96,7 +102,7 @@ int main(int argc, char *argv[])
 
     glXMakeContextCurrent(dpy, glxWin, glxWin, context);
 
-    glViewport(0, 0, 256, 256);
+    glViewport(0, 0, TARGET_WIDTH, TARGET_HEIGHT);
 
     glEnable(GL_DEBUG_OUTPUT);
     glDebugMessageCallback(debug_message, NULL);
@@ -113,9 +119,9 @@ int main(int argc, char *argv[])
     /* Prep a test texture image, grabbing a small chunk of the root
      * window */
     {
-        XImage *img = XGetImage(dpy, DefaultRootWindow(dpy), 0, 0, 100, 100, AllPlanes, ZPixmap);
+        XImage *img = XGetImage(dpy, DefaultRootWindow(dpy), 0, 0, SOURCE_WIDTH, SOURCE_HEIGHT, AllPlanes, ZPixmap);
         assert(img->bits_per_pixel == 32);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 100, 100, 0, GL_BGRA, GL_UNSIGNED_BYTE, img->data);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, SOURCE_WIDTH, SOURCE_HEIGHT, 0, GL_BGRA, GL_UNSIGNED_BYTE, img->data);
         CHECK_ERROR("loading texture");
         XDestroyImage(img);
     }
@@ -123,7 +129,7 @@ int main(int argc, char *argv[])
     glEnable(GL_TEXTURE_2D);
 
     /* Set up the display coordinate space as orthographic */
-    glOrtho(0.0d, 256.0d, 256.0d, 0.0d, -1.0d, 1.0d);
+    glOrtho(0.0d, TARGET_WIDTH, TARGET_HEIGHT, 0.0d, -1.0d, 1.0d);
     CHECK_ERROR("setting transforms");
 
     /* If we don't set the mapping filters, we get a blank image */
@@ -139,11 +145,11 @@ int main(int argc, char *argv[])
     glTexCoord2i(0, 0);
     glVertex2i(0, 0);
     glTexCoord2i(1, 0);
-    glVertex2i(256, 0);
+    glVertex2i(TARGET_WIDTH, 0);
     glTexCoord2i(1, 1);
-    glVertex2i(256, 256);
+    glVertex2i(TARGET_WIDTH, TARGET_HEIGHT);
     glTexCoord2i(0, 1);
-    glVertex2i(0, 256);
+    glVertex2i(0, TARGET_HEIGHT);
     glEnd();
     CHECK_ERROR("rasterizing the quadrangle");
 

--- a/probe/fbconfig/fbconfig.c
+++ b/probe/fbconfig/fbconfig.c
@@ -6,6 +6,15 @@
 
 #include <unistd.h>
 
+#define CHECK_ERROR(context)                                         \
+    do {                                                             \
+        int error = glGetError();                                    \
+            if (error) {                                             \
+                fprintf(stderr, "GL error 0x%x while " context "\n", \
+                        error);                                      \
+            }                                                        \
+    } while (0)
+
 typedef void (APIENTRY *DEBUGPROC)(GLenum source,
                                    GLenum type,
                                    GLuint id,
@@ -86,16 +95,58 @@ int main(int argc, char *argv[])
 
     glXMakeContextCurrent(dpy, glxWin, glxWin, context);
 
+    glViewport(0, 0, 256, 256);
+
     glEnable(GL_DEBUG_OUTPUT);
     glDebugMessageCallback(debug_message, NULL);
 
     GLuint textures = 0;
     glGenTextures(1, &textures);
-    glBindTexture(GL_TEXTURE_2D, textures);
+    CHECK_ERROR("making texture");
 
-    glClearColor(1.0f, 0.0f, 0.0f, 1.0f);
-    glClear(GL_COLOR_BUFFER_BIT);
+    /* All texture operations function in terms of a "current
+     * texture".  Set it here */
+    glBindTexture(GL_TEXTURE_2D, textures);
+    CHECK_ERROR("binding texture");
+
+    /* Prep a test texture image, grabbing a small chunk of the root
+     * window */
+    {
+        XImage *img = XGetImage(dpy, DefaultRootWindow(dpy), 0, 0, 100, 100, AllPlanes, ZPixmap);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 100, 100, 0, GL_RGBA, GL_UNSIGNED_BYTE, img->data);
+        CHECK_ERROR("loading texture");
+        XDestroyImage(img);
+    }
+
+    glEnable(GL_TEXTURE_2D);
+
+    /* Set up the display coordinate space as orthographic */
+    glOrtho(0.0d, 256.0d, 256.0d, 0.0d, -1.0d, 1.0d);
+    CHECK_ERROR("setting transforms");
+
+    /* If we don't set the mapping filters, we get a blank image */
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    /* Use the "legacy" (deprecated, possibly no longer supported by
+     * open-source drivers) "immediate mode" APIs to render a
+     * window-sized rectangle from the texture image */
+    glBegin(GL_QUADS);
+    /* Texture coordinates are from 0 to 1, output coordinates are
+     * from 0 to width/height */
+    glTexCoord2i(0, 0);
+    glVertex2i(0, 0);
+    glTexCoord2i(1, 0);
+    glVertex2i(256, 0);
+    glTexCoord2i(1, 1);
+    glVertex2i(256, 256);
+    glTexCoord2i(0, 1);
+    glVertex2i(0, 256);
+    glEnd();
+    CHECK_ERROR("rasterizing the quadrangle");
+
     glFlush();
+    CHECK_ERROR("flush");
 
     glXSwapBuffers(dpy, glxWin);
     sleep(10);

--- a/probe/fbconfig/fbconfig.c
+++ b/probe/fbconfig/fbconfig.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -113,7 +114,8 @@ int main(int argc, char *argv[])
      * window */
     {
         XImage *img = XGetImage(dpy, DefaultRootWindow(dpy), 0, 0, 100, 100, AllPlanes, ZPixmap);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 100, 100, 0, GL_RGBA, GL_UNSIGNED_BYTE, img->data);
+        assert(img->bits_per_pixel == 32);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 100, 100, 0, GL_BGRA, GL_UNSIGNED_BYTE, img->data);
         CHECK_ERROR("loading texture");
         XDestroyImage(img);
     }


### PR DESCRIPTION
This may-or-may-not work on any given OpenGL implementation.  Apparently, "legacy" support is being removed from (some?) modern drivers, and non-"legacy" support requires shaders.

Threw in some error-checking, largely to make sure that I got some sort of diagnostic for the more egregious errors, such as invalid parameters to glTexImage2D().

Anyway, net effect is to grab a 100x100 pixel chunk of the top-left corner of the screen and scale it up to fit a 256x256 window.