### PR TITLE
Expand config handling

### DIFF
--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -59,6 +59,8 @@ proc main() =
 
   if existsFile configFile:
     config = loadConfig(configFile)
+  else:
+    stderr.writeLine configFile & " doesn't exist. Using default values. "
 
   echo "Using config: ", config
 

--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -51,10 +51,13 @@ const
 
 proc main() =
   var config = defaultConfig
-  var configFile = ""
+  let configFile = block:
+    if paramCount() > 0:
+      paramStr(1)
+    else:
+      getConfigDir() / "boomer" / "config"
 
-  if paramCount() > 0:
-    configFile = paramStr(1)
+  if existsFile configFile:
     config = loadConfig(configFile)
 
   echo "Using config: ", config

--- a/src/config.nim
+++ b/src/config.nim
@@ -1,5 +1,4 @@
-import macros
-import strutils
+import macros, strutils
 
 type Config* = object
   scrollSpeed*: float
@@ -16,22 +15,37 @@ const defaultConfig* = Config(
   fps: 60
 )
 
+func normIdent(s: string): string =
+  if s.len > 0:
+    result.add s[0]
+    for i in 1..s.high:
+      if s[i] != '_':
+        result.add s[i].toLowerAscii
+
+macro parseObject(obj: typed, key, val: string) =
+  result = newNimNode(nnkCaseStmt).add(newCall("normIdent", key))
+  for c in obj.getType[2]:
+    let a = case c.getType.typeKind
+    of ntyFloat:
+      newCall("parseFloat", val)
+    of ntyInt:
+      newCall("parseInt", val)
+    of ntyString:
+      val
+    else:
+      error "Unsupported type: " & c.getType.`$`
+      val
+    result.add newNimNode(nnkOfBranch).add(
+      newLit normIdent $c,
+      newStmtList(quote do: `obj`.`c` = `a`)
+    )
+  result.add newNimNode(nnkElse).add(quote do:
+    raise newException(CatchableError, "Unknown config key " & `key`))
+
 proc loadConfig*(filePath: string): Config =
   result = defaultConfig
   for line in filePath.lines:
-    let pair = line.split('=')
+    let pair = line.split('=', 1)
     let key = pair[0].strip
     let value = pair[1].strip
-    case key
-    of "scroll_speed":
-      result.scroll_speed = value.parseFloat
-    of "drag_velocity_factor":
-      result.drag_velocity_factor = value.parseFloat
-    of "drag_friction":
-      result.drag_friction = value.parseFloat
-    of "scale_friction":
-      result.scale_friction = value.parseFloat
-    of "fps":
-      result.fps = value.parseInt
-    else:
-      raise newException(Exception, "Unknown config key " & key)
+    result.parseObject key, value

--- a/src/config.nim
+++ b/src/config.nim
@@ -15,15 +15,8 @@ const defaultConfig* = Config(
   fps: 60
 )
 
-func normIdent(s: string): string =
-  if s.len > 0:
-    result.add s[0]
-    for i in 1..s.high:
-      if s[i] != '_':
-        result.add s[i].toLowerAscii
-
 macro parseObject(obj: typed, key, val: string) =
-  result = newNimNode(nnkCaseStmt).add(newCall("normIdent", key))
+  result = newNimNode(nnkCaseStmt).add(key)
   for c in obj.getType[2]:
     let a = case c.getType.typeKind
     of ntyFloat:
@@ -36,7 +29,7 @@ macro parseObject(obj: typed, key, val: string) =
       error "Unsupported type: " & c.getType.`$`
       val
     result.add newNimNode(nnkOfBranch).add(
-      newLit normIdent $c,
+      newLit $c,
       newStmtList(quote do: `obj`.`c` = `a`)
     )
   result.add newNimNode(nnkElse).add(quote do:


### PR DESCRIPTION
If no config file specified reads config from `${XDG_CONFIG_DIR:-~/.config}/boomer/config`.
Also now config parsing is performed automatically according to object fields.

In current state macro expands to following code:
```nim
case normIdent(key)
of "scrollspeed":
  result.scrollSpeed = parseFloat(value)
of "dragvelocityfactor":
  result.dragVelocityFactor = parseFloat(value)
of "dragfriction":
  result.dragFriction = parseFloat(value)
of "scalefriction":
  result.scaleFriction = parseFloat(value)
of "fps":
  result.fps = parseInt(value)
else:
  raise
    var e`gensym340155: owned(ref CatchableError)
    new(e`gensym340155)
    e`gensym340155.msg = "Unknown config key " & key
    e`gensym340155.parent = nil
    e`gensym340155
```

Which is almost exactly the same as handwritten one, except identifiers are compared style insensitively, so you dont have to follow exact field naming in the config. Also value are automatically parsed to int/float and additional handling can be added as needed.