### PR TITLE
adding WM_CLASS attributes

### DIFF
--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -114,10 +114,9 @@ proc main() =
   var wmName = "boomer"
   var wmClass = "Boomer"
   var hints = TXClassHint(res_name: wmName, res_class: wmClass)
-  var pHints: PXClassHint = addr(hints)
-
+  
   discard XStoreName(display, win, wmName)
-  discard XSetClassHint(display, win, pHints)
+  discard XSetClassHint(display, win, addr(hints))
 
   var wmDeleteMessage = XInternAtom(
     display, "WM_DELETE_WINDOW",

--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -110,7 +110,14 @@ proc main() =
     CWColormap or CWEventMask, addr swa)
 
   discard XMapWindow(display, win)
-  discard XStoreName(display, win, "Wordpress Application")
+
+  var wmName = "boomer"
+  var wmClass = "Boomer"
+  var hints = TXClassHint(res_name: wmName, res_class: wmClass)
+  var pHints: PXClassHint = addr(hints)
+
+  discard XStoreName(display, win, wmName)
+  discard XSetClassHint(display, win, pHints)
 
   var wmDeleteMessage = XInternAtom(
     display, "WM_DELETE_WINDOW",


### PR DESCRIPTION
Many Tiling Window Manager use WM_CLASS to manage window (eg. BSPWM).

I am reeally enjoying you streams on TWITCH and cant wait to see where this goes. I use BSPWM and using 'boomer' with it to make it fullscreen, i need WM_CLASS attribute, otherwise it just get tiled. So I implemented one (it's my second time trying NIM, sorry if **anything** is bad  - there are less than 10 lines)