### PR TITLE
Remove the warning message from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Zoomer application for Linux.
 - Development is done on https://twitch.tv/tsoding
 - Archive of the streams: https://www.twitch.tv/collections/HlRy-q69uBXmpQ
 
-**WARNING! The application is in an active development state and is
-not even alpha yet. Use it at your own risk. Nothing is documented,
-anything can be changed at any moment or stop working at all.**
-
 ## Dependencies
 
 ### Debian


### PR DESCRIPTION
As of 29-01-2020 boomer is in the official release stage, which means the warning message in README is obsolete and doesn't represent the current state of the project.
Because of that, I think it's best to remove it.