### PR TITLE
Introduce min_scale config

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Supported parameters:
 
 | Name           | Description                                        |
 |----------------|----------------------------------------------------|
+| min_scale      | The smallest it can get when zooming out           |
 | scroll_speed   | How quickly you can zoom in/out by scrolling       |
 | drag_friction  | How quickly the movement slows down after dragging |
 | scale_friction | How quickly the zoom slows down after scrolling    |

--- a/src/config.nim
+++ b/src/config.nim
@@ -1,11 +1,13 @@
 import macros, strutils
 
 type Config* = object
+  min_scale*: float
   scroll_speed*: float
   drag_friction*: float
   scale_friction*: float
 
 const defaultConfig* = Config(
+  min_scale: 1,
   scroll_speed: 1.5,
   drag_friction: 6.0,
   scale_friction: 4.0,
@@ -21,6 +23,8 @@ proc loadConfig*(filePath: string): Config =
     let key = pair[0].strip
     let value = pair[1].strip
     case key
+    of "min_scale":
+      result.min_scale = parseFloat(value)
     of "scroll_speed":
       result.scroll_speed = parseFloat(value)
     of "drag_friction":
@@ -33,6 +37,7 @@ proc loadConfig*(filePath: string): Config =
 proc generateDefaultConfig*(filePath: string) =
   var f = open(filePath, fmWrite)
   defer: f.close
+  f.write("min_scale = ", defaultConfig.min_scale, "\n")
   f.write("scroll_speed = ", defaultConfig.scroll_speed, "\n")
   f.write("drag_friction = ", defaultConfig.drag_friction, "\n")
   f.write("scale_friction = ", defaultConfig.scale_friction, "\n")

--- a/src/config.nim
+++ b/src/config.nim
@@ -7,7 +7,7 @@ type Config* = object
   scale_friction*: float
 
 const defaultConfig* = Config(
-  min_scale: 1,
+  min_scale: 0.01,
   scroll_speed: 1.5,
   drag_friction: 6.0,
   scale_friction: 4.0,

--- a/src/navigation.nim
+++ b/src/navigation.nim
@@ -23,7 +23,7 @@ proc world*(camera: Camera, v: Vec2f): Vec2f =
 proc update*(camera: var Camera, config: Config, dt: float, mouse: Mouse, image: PXImage, windowSize: Vec2f) =
   if abs(camera.deltaScale) > 0.5:
     let p0 = (camera.scalePivot - (windowSize * 0.5)) / camera.scale
-    camera.scale = max(camera.scale + camera.delta_scale * dt, 0.01)
+    camera.scale = max(camera.scale + camera.delta_scale * dt, config.min_scale)
     let p1 = (camera.scalePivot - (windowSize * 0.5)) / camera.scale
     camera.position += p0 - p1
 


### PR DESCRIPTION
'min_scale' is added to config and it gets parsed from the config file. It changes how small the content can get when zooming out, although the default value is the same as previous versions