### PR TITLE
Add flashlight_starts_enabled to config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ You can generate a new config at `$HOME/.config/boomer/config` with `$ boomer --
 
 Supported parameters:
 
-| Name           | Description                                        |
-|----------------|----------------------------------------------------|
-| min_scale      | The smallest it can get when zooming out           |
-| scroll_speed   | How quickly you can zoom in/out by scrolling       |
-| drag_friction  | How quickly the movement slows down after dragging |
-| scale_friction | How quickly the zoom slows down after scrolling    |
+| Name                      | Description                                         |
+|---------------------------|-----------------------------------------------------|
+| min_scale                 | The smallest it can get when zooming out            |
+| scroll_speed              | How quickly you can zoom in/out by scrolling        |
+| drag_friction             | How quickly the movement slows down after dragging  |
+| scale_friction            | How quickly the zoom slows down after scrolling     |
+| flashlight_starts_enabled | If the flashlight is enabled when boomer is started | 
 
 ## Experimental Features Compilation Flags
 

--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -428,7 +428,7 @@ proc main() =
         let pos = getCursorPosition(display)
         Mouse(curr: pos, prev: pos)
     flashlight = Flashlight(
-      isEnabled: false,
+      isEnabled: config.flashlight_starts_enabled,
       radius: 200.0)
 
 

--- a/src/config.nim
+++ b/src/config.nim
@@ -5,12 +5,14 @@ type Config* = object
   scroll_speed*: float
   drag_friction*: float
   scale_friction*: float
+  flashlight_starts_enabled*: bool
 
 const defaultConfig* = Config(
   min_scale: 0.01,
   scroll_speed: 1.5,
   drag_friction: 6.0,
   scale_friction: 4.0,
+  flashlight_starts_enabled: false
 )
 
 proc loadConfig*(filePath: string): Config =
@@ -31,6 +33,8 @@ proc loadConfig*(filePath: string): Config =
       result.drag_friction = parseFloat(value)
     of "scale_friction":
       result.scale_friction = parseFloat(value)
+    of "flashlight_starts_enabled":
+      result.flashlight_starts_enabled = parseBool(value)
     else:
       quit "Unknown config key `$#`" % [key]
 
@@ -41,3 +45,4 @@ proc generateDefaultConfig*(filePath: string) =
   f.write("scroll_speed = ", defaultConfig.scroll_speed, "\n")
   f.write("drag_friction = ", defaultConfig.drag_friction, "\n")
   f.write("scale_friction = ", defaultConfig.scale_friction, "\n")
+  f.write("flashlight_starts_enabled = ", defaultConfig.flashlight_starts_enabled, "\n")


### PR DESCRIPTION
I hope you don't mind a PR without a corresponding Issue. If you do mind or have other preferences when it comes to people creating PRs, please let me know.

I love this tool but I found I always immediately enable the flashlight. This change adds a config option to have boomer start with the flashlight enabled, defaulting to false.

Note: this change is backwards compatible with existing config files.