### PR TITLE
Use const for constants to avoid warnings

### DIFF
--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -329,8 +329,8 @@ proc main() =
 
   discard XMapWindow(display, win)
 
-  var wmName = "boomer"
-  var wmClass = "Boomer"
+  const wmName = "boomer"
+  const wmClass = "Boomer"
   var hints = XClassHint(res_name: wmName, res_class: wmClass)
 
   discard XStoreName(display, win, wmName)


### PR DESCRIPTION
This fixes the annoying warning:
`Warning: implicit conversion to 'cstring' from a non-const location: wmName; this will become a compile time error in the future [CStringConv]`