### PR TITLE
Added error if you're not using X11

### DIFF
--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -15,8 +15,14 @@ import la
 import strutils
 import math
 import options
+import system
 
 type Shader = tuple[path, content: string]
+
+proc check_x11() =
+  if getEnv("XDG_SESSION_TYPE") != "x11":
+    echo "ERROR: Boomer doesn't work on Wayland..."
+    system.quit(1)
 
 proc readShader(file: string): Shader =
   when nimvm:
@@ -179,6 +185,8 @@ proc main() =
   var configFile = boomerDir / "config"
   var windowed = false
   var delaySec = 0.0
+
+  check_x11()
 
   # TODO(#95): Make boomer optionally wait for some kind of event (for example, key press)
   block:


### PR DESCRIPTION
I made sure that if you're using wayland, that boomer says something, then quits. I've tried a few things for boomer to run on wayland, but it just can't.