### PR TITLE
Introduce invert_fl_scroll config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ You can generate a new config at `$HOME/.config/boomer/config` with `$ boomer --
 
 Supported parameters:
 
-| Name           | Description                                        |
-|----------------|----------------------------------------------------|
-| min_scale      | The smallest it can get when zooming out           |
-| scroll_speed   | How quickly you can zoom in/out by scrolling       |
-| drag_friction  | How quickly the movement slows down after dragging |
-| scale_friction | How quickly the zoom slows down after scrolling    |
+| Name             | Description                                        |
+|------------------|----------------------------------------------------|
+| min_scale        | The smallest it can get when zooming out           |
+| scroll_speed     | How quickly you can zoom in/out by scrolling       |
+| drag_friction    | How quickly the movement slows down after dragging |
+| scale_friction   | How quickly the zoom slows down after scrolling    |
+| invert_fl_scroll | Reverses the scroll directions for the flashlight  |
 
 ## Experimental Features Compilation Flags
 

--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -450,14 +450,14 @@ proc main() =
 
       proc scrollUp() =
         if (xev.xkey.state and ControlMask) > 0.uint32 and flashlight.isEnabled:
-          flashlight.deltaRadius += INITIAL_FL_DELTA_RADIUS
+          flashlight.deltaRadius += INITIAL_FL_DELTA_RADIUS * (if config.invert_fl_scroll: -1.0 else: 1.0)
         else:
           camera.deltaScale += config.scrollSpeed
           camera.scalePivot = mouse.curr
 
       proc scrollDown() =
         if (xev.xkey.state and ControlMask) > 0.uint32 and flashlight.isEnabled:
-          flashlight.deltaRadius -= INITIAL_FL_DELTA_RADIUS
+          flashlight.deltaRadius -= INITIAL_FL_DELTA_RADIUS * (if config.invert_fl_scroll: -1.0 else: 1.0)
         else:
           camera.deltaScale -= config.scrollSpeed
           camera.scalePivot = mouse.curr

--- a/src/config.nim
+++ b/src/config.nim
@@ -5,12 +5,14 @@ type Config* = object
   scroll_speed*: float
   drag_friction*: float
   scale_friction*: float
+  invert_fl_scroll*: bool
 
 const defaultConfig* = Config(
   min_scale: 0.01,
   scroll_speed: 1.5,
   drag_friction: 6.0,
   scale_friction: 4.0,
+  invert_fl_scroll: false,
 )
 
 proc loadConfig*(filePath: string): Config =
@@ -31,6 +33,8 @@ proc loadConfig*(filePath: string): Config =
       result.drag_friction = parseFloat(value)
     of "scale_friction":
       result.scale_friction = parseFloat(value)
+    of "invert_fl_scroll":
+      result.invert_fl_scroll = parseBool(value)
     else:
       quit "Unknown config key `$#`" % [key]
 
@@ -41,3 +45,4 @@ proc generateDefaultConfig*(filePath: string) =
   f.write("scroll_speed = ", defaultConfig.scroll_speed, "\n")
   f.write("drag_friction = ", defaultConfig.drag_friction, "\n")
   f.write("scale_friction = ", defaultConfig.scale_friction, "\n")
+  f.write("invert_fl_scroll = ", defaultConfig.invert_fl_scroll, "\n")


### PR DESCRIPTION
I personally found it unintuitive to narrow the flashlight circle by scrolling down, so I added an option to invert the scrolling behaviour specifically for the flashlight. I can't be the only one, so I thought I might as well create a PR and maybe you'll get around to merging it one day.