### PR TITLE
Fix: Revert vertices_foo back to vertices

### DIFF
--- a/src/boomer.nim
+++ b/src/boomer.nim
@@ -358,7 +358,7 @@ proc main() =
   let h = screenshot.image.height.float32
   var
     vao, vbo, ebo: GLuint
-    vertices_foo = [
+    vertices = [
       # Position            Texture coords
       [GLfloat    w,     0, 1.0, 1.0], # Top right
       [GLfloat    w,     h, 1.0, 0.0], # Bottom right
@@ -379,14 +379,14 @@ proc main() =
   glBindVertexArray(vao)
 
   glBindBuffer(GL_ARRAY_BUFFER, vbo)
-  glBufferData(GL_ARRAY_BUFFER, size = GLsizeiptr(sizeof(vertices_foo)),
-               addr vertices_foo, GL_STATIC_DRAW)
+  glBufferData(GL_ARRAY_BUFFER, size = GLsizeiptr(sizeof(vertices)),
+               addr vertices, GL_STATIC_DRAW)
 
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, size = GLsizeiptr(sizeof(indices)),
                addr indices, GL_STATIC_DRAW);
 
-  var stride = GLsizei(vertices_foo[0].len * sizeof(GLfloat))
+  var stride = GLsizei(vertices[0].len * sizeof(GLfloat))
 
   glVertexAttribPointer(0, 2, cGL_FLOAT, false, stride, cast[pointer](0))
   glEnableVertexAttribArray(0)


### PR DESCRIPTION
Hey!

While watching the development of the mirror feature, I noticed that the `vertices` array was temporarily renamed to `vertices_foo` to get compiler-assisted refactoring. It seems the temporary name was accidentally left as `vertices_foo` in the code, so I made this quick PR to revert it back to `vertices`.  

Thanks for the awesome project!